### PR TITLE
[MariaDBStream] Adds option to replicate only selected databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ List of features currently available:
 - UI to see and select an available backup to restore to
 - UI shows status of backup verification
 - UI/API can be secured via OAuth openID
-- Replication via a full dump and binlog to another MariaDB
-  - restore from the replica is not supported
+- Replication of full dump and binlog events to another MariaDB
+  - only QueryEvents are supported
+  - restore from this replicas MariaDB is not supported
+  - verification of this replica is not supported
 
 ## UI
 The UI is available via localhost:8081/
@@ -106,6 +108,7 @@ storage_services:
       user: # MariaDB user with admin rights
       password: # user password
       full_dump_tool: # dump tool used to restore the full dump
+      databases: # if specified, only the listed databases are replicated
   disk:
     - base_path: # root folder for the backups
       retention: # backup retention in number of full backups

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,13 +123,13 @@ type Disk struct {
 
 // MariaDBStream holds info for the replication to another MariaDB
 type MariaDBStream struct {
-	Name             string    `yaml:"name"`
-	Host             string    `yaml:"host"`
-	Port             int       `yaml:"port"`
-	User             string    `yaml:"user"`
-	Password         string    `yaml:"password"`
-	DumpTool         DumpTools `yaml:"full_dump_tool"`
-	ReplicateSchemas []string  `yaml:"replicate_schemas"`
+	Name      string    `yaml:"name"`
+	Host      string    `yaml:"host"`
+	Port      int       `yaml:"port"`
+	User      string    `yaml:"user"`
+	Password  string    `yaml:"password"`
+	DumpTool  DumpTools `yaml:"full_dump_tool"`
+	Databases []string  `yaml:"databases"`
 }
 
 // OAuth holds info for the api oauth middleware

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,12 +123,13 @@ type Disk struct {
 
 // MariaDBStream holds info for the replication to another MariaDB
 type MariaDBStream struct {
-	Name     string    `yaml:"name"`
-	Host     string    `yaml:"host"`
-	Port     int       `yaml:"port"`
-	User     string    `yaml:"user"`
-	Password string    `yaml:"password"`
-	DumpTool DumpTools `yaml:"full_dump_tool"`
+	Name             string    `yaml:"name"`
+	Host             string    `yaml:"host"`
+	Port             int       `yaml:"port"`
+	User             string    `yaml:"user"`
+	Password         string    `yaml:"password"`
+	DumpTool         DumpTools `yaml:"full_dump_tool"`
+	ReplicateSchemas []string  `yaml:"replicate_schemas"`
 }
 
 // OAuth holds info for the api oauth middleware

--- a/pkg/storage/mariadb.go
+++ b/pkg/storage/mariadb.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -38,8 +39,10 @@ import (
 
 // MariaDBStream struct is ...
 type MariaDBStream struct {
+	// db connection to the target db
 	db          *sql.DB
 	cfg         config.MariaDBStream
+	replSchemas map[string]struct{}
 	serviceName string
 	statusError map[string]string
 }
@@ -55,9 +58,16 @@ func NewMariaDBStream(c config.MariaDBStream, serviceName string) (m *MariaDBStr
 		return nil, fmt.Errorf("failed to ping db %s: %s", serviceName, err.Error())
 	}
 
+	replSchemas := make(map[string]struct{}, len(c.ReplicateSchemas))
+
+	for _, schema := range c.ReplicateSchemas {
+		replSchemas[schema] = struct{}{}
+	}
+
 	return &MariaDBStream{
 		db:          db,
 		cfg:         c,
+		replSchemas: replSchemas,
 		serviceName: serviceName,
 	}, nil
 }
@@ -82,6 +92,12 @@ func (m *MariaDBStream) WriteChannel(name, mimeType string, body <-chan StreamEv
 			switch event.Header.EventType {
 			case replication.QUERY_EVENT:
 				queryEvent := event.Event.(*replication.QueryEvent)
+
+				if _, ok := m.replSchemas[string(queryEvent.Schema)]; !ok {
+					// only schemas
+					continue
+				}
+
 				err = replicateQueryEvent(ctx, m.db, queryEvent)
 				if err != nil {
 					return fmt.Errorf("replication of query failed: %s", err.Error())
@@ -126,8 +142,18 @@ func (m *MariaDBStream) GetStatusErrorByKey(backupKey string) string {
 // WriteFolder implements interface
 func (m *MariaDBStream) WriteFolder(p string) (err error) {
 	log.Debug("SQL dump path: ", p)
+	backupPath := path.Join(p, "dump.sql")
 
-	dump, err := os.Open(path.Join(p, "dump.sql"))
+	// Should the full dump be filtered to certain DB schemas?
+	if m.cfg.ReplicateSchemas != nil {
+		log.Debug("Extracting schemas from full backup")
+		backupPath, err = m.extractSchemas(backupPath)
+		if err != nil {
+			return fmt.Errorf("failed to write folder: %s", err.Error())
+		}
+	}
+
+	dump, err := os.Open(backupPath)
 	if err != nil {
 		return fmt.Errorf("could not read dump: %s", err.Error())
 	}
@@ -196,6 +222,66 @@ func replicateQueryEvent(ctx context.Context, db *sql.DB, event *replication.Que
 		return fmt.Errorf("execution of query failed: %v", err.Error())
 	}
 	return
+}
+
+// extractSchemas filters the full backup dump.sql and only retains statements for schemas specified in the config
+func (m *MariaDBStream) extractSchemas(backupPath string) (filteredBackup string, err error) {
+	filteredBackupPath := filepath.Join(filepath.Base(backupPath), "dump_filtered.sql")
+	file, err := os.Create(filteredBackupPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create file for filtered backup: %s", err.Error())
+	}
+	defer file.Close()
+	bytes, err := m.extractBackupMetadata(backupPath)
+	if err != nil {
+		return "", fmt.Errorf("could not extract metadata from full backup: %s", err.Error())
+	}
+	_, err = file.Write(bytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to write backup metadata: %s", err.Error())
+	}
+
+	for _, s := range m.cfg.ReplicateSchemas {
+		bytes, err := m.extractSchema(backupPath, s)
+		if err != nil {
+			return "", fmt.Errorf("could not extract schema %s from full backup: %s", s, err.Error())
+		}
+		_, err = file.Write(bytes)
+		if err != nil {
+			return "", fmt.Errorf("failed to write schema %s to file: %s", s, err.Error())
+		}
+	}
+	file.Close()
+	return filteredBackup, nil
+}
+
+// getBackupMetadata extracts the backup metadata from the full dump
+func (m *MariaDBStream) extractBackupMetadata(path string) (bytes []byte, err error) {
+	cmd := exec.Command(
+		"sed",
+		"-n", "/^-- MariaDB dump /,/^-- Current Database: `/p",
+		path,
+	)
+	out, err := cmd.Output()
+
+	if err != nil {
+		return nil, fmt.Errorf("could not extract backup metadata from backup: %s", err.Error())
+	}
+	return out, nil
+}
+
+// extractSchema filters the full backup for all statements related to `schema`
+func (m *MariaDBStream) extractSchema(path, schema string) (bytes []byte, err error) {
+	cmd := exec.Command(
+		"sed",
+		"-n", fmt.Sprintf("/^-- Current Database: `%s`/,/^-- Current Database: `/p", schema),
+		path,
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("could not extract schema %s from backup: %s", schema, err.Error())
+	}
+	return out, nil
 }
 
 // DownloadLatestBackup implements interface

--- a/pkg/test/mariadb_integration_test.go
+++ b/pkg/test/mariadb_integration_test.go
@@ -74,10 +74,10 @@ func TestBackupRestore(t *testing.T) {
 
 func testBackupRestore(t *testing.T, test testCase) {
 	m, cfg := Setup(t, &SetupOptions{
-		DBType:            constants.MARIADB,
-		DumpTool:          config.Mysqldump,
-		WithDiskStorage:   test.WithDisk,
-		WithStreamStorage: test.WithStream,
+		DBType:          constants.MARIADB,
+		DumpTool:        config.Mysqldump,
+		WithDiskStorage: test.WithDisk,
+		StreamStorage:   &StreamStorageOptions{Enabled: test.WithStream},
 	})
 
 	// Perform Backup

--- a/pkg/test/setup.go
+++ b/pkg/test/setup.go
@@ -42,8 +42,8 @@ const clearDBFile = "./testclean.sql"
 
 // StreamStorageOptions to configure test setup
 type StreamStorageOptions struct {
-	Enabled          bool
-	ReplicateSchemas []string
+	Enabled   bool
+	Databases []string
 }
 
 //SetupOptions contains optional arguments for test.Setup().
@@ -89,13 +89,13 @@ func Setup(t *testing.T, opts *SetupOptions) (m *backup.Manager, cfg config.Conf
 
 	if opts.StreamStorage.Enabled {
 		cfg.Storages.MariaDB = []config.MariaDBStream{{
-			Name:             "StreamingTest",
-			Host:             "127.0.0.1",
-			Port:             3307,
-			User:             "root",
-			Password:         "streaming",
-			DumpTool:         config.Mysqldump,
-			ReplicateSchemas: opts.StreamStorage.ReplicateSchemas,
+			Name:      "StreamingTest",
+			Host:      "127.0.0.1",
+			Port:      3307,
+			User:      "root",
+			Password:  "streaming",
+			DumpTool:  config.Mysqldump,
+			Databases: opts.StreamStorage.Databases,
 		}}
 	}
 

--- a/pkg/test/streaming_integration_test.go
+++ b/pkg/test/streaming_integration_test.go
@@ -31,8 +31,8 @@ func TestFilterBackup(t *testing.T) {
 		DBType:   constants.MARIADB,
 		DumpTool: config.Mysqldump,
 		StreamStorage: &StreamStorageOptions{
-			Enabled:          true,
-			ReplicateSchemas: []string{"service"},
+			Enabled:   true,
+			Databases: []string{"service"},
 		}})
 
 	// Perform Backup

--- a/pkg/test/streaming_integration_test.go
+++ b/pkg/test/streaming_integration_test.go
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2021 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sapcc/maria-back-me-up/pkg/config"
+	"github.com/sapcc/maria-back-me-up/pkg/constants"
+	"github.com/siddontang/go-mysql/mysql"
+)
+
+func TestFilterBackup(t *testing.T) {
+	m, cfg := Setup(t, &SetupOptions{
+		DBType:   constants.MARIADB,
+		DumpTool: config.Mysqldump,
+		StreamStorage: &StreamStorageOptions{
+			Enabled:          true,
+			ReplicateSchemas: []string{"service"},
+		}})
+
+	// Perform Backup
+	err := m.Start()
+	if err != nil {
+		t.Errorf("could not start backup: %s", err.Error())
+		t.FailNow()
+	}
+
+	// Create DB client
+	conn, err := createConnection(cfg.Database.User, cfg.Database.Password, cfg.Database.Host, "", cfg.Database.Port)
+	if err != nil {
+		t.Errorf("could not connect to database: %s", err.Error())
+		t.FailNow()
+	}
+	defer conn.Close()
+
+	_, err = conn.Execute("INSERT INTO service.tasks (title, start_date, due_date, description) VALUES('task5', '2021-05-02', '2022-05-02', 'task info 5');")
+	if err != nil {
+		t.Errorf("failed to write to db: %s", err.Error())
+	}
+	_, err = conn.Execute("INSERT INTO application.ratings (title, release_date, description, rating) VALUES('app5', '2021-05-02', 'app info 5', 4);")
+	if err != nil {
+		t.Errorf("failed to write to db: %s", err.Error())
+	}
+	time.Sleep(time.Second * 15)
+	m.Stop()
+
+	// Check streaming target db
+	assertTableConsistent(t, "root", "streaming", "127.0.0.1", "service", 3307, 5, "tasks")
+	assertDatabaseNotExists(t, "root", "streaming", "127.0.0.1", "application", 3307)
+
+	Cleanup(t)
+}
+
+func assertDatabaseNotExists(t *testing.T, user, password, host, db string, port int) {
+	conn, err := createConnection(user, password, host, db, port)
+	if err != nil {
+		if mysqlErr, ok := errors.Cause(err).(*mysql.MyError); ok {
+			if mysqlErr.Code == 1049 {
+				return
+			}
+		}
+		t.Errorf("unexpected error: %s", err.Error())
+		return
+	}
+	t.Errorf("expected an error")
+	defer conn.Close()
+}

--- a/pkg/test/testclean.sql
+++ b/pkg/test/testclean.sql
@@ -1,1 +1,2 @@
 DROP DATABASE IF EXISTS service;
+DROP DATABASE IF EXISTS application;

--- a/pkg/test/testdata.sql
+++ b/pkg/test/testdata.sql
@@ -21,3 +21,27 @@ INSERT INTO service.tasks (title, start_date, due_date, description)
 
 INSERT INTO service.tasks (title, start_date, due_date, description)
         VALUES('task4', '2021-05-02', '2022-05-02', 'task info 4');
+
+DROP DATABASE IF EXISTS dummy;
+
+CREATE DATABASE IF NOT EXISTS application;
+
+CREATE TABLE IF NOT EXISTS application.ratings( 
+  app_id INT AUTO_INCREMENT PRIMARY KEY, 
+    title VARCHAR(255) NOT NULL,  
+    release_date DATE, 
+    description TEXT,
+    rating INT
+    ) ENGINE=INNODB;
+
+INSERT INTO application.ratings (title, release_date, description, rating)
+        VALUES('app1', '2021-05-02', 'app info 1', 4);
+
+INSERT INTO application.ratings (title, release_date, description, rating)
+        VALUES('app2', '2021-05-02', 'app info 2', 5);
+
+INSERT INTO application.ratings (title, release_date, description, rating)
+        VALUES('app3', '2021-05-02','app info 3', 3);
+
+INSERT INTO application.ratings (title, release_date, description, rating)
+        VALUES('app4', '2021-05-02', 'app info 4', 0);


### PR DESCRIPTION
- adds config option to add a list of databases for stream storage
- if databases specified
  - filter out meta statements from beginning of full backup sql file
  - filter out statements belonging to the selected dbs
  - only replicate QueryEvents that match one of the dbs

This is intended for the use case that the fullbackups including the mysql schema are stored to Swift/S3 but a subset of tables is replicated to a read-only replica.