### PR TITLE
Adds flag PurgeBinlogAfterMinutes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,6 +57,7 @@ type BackupService struct {
 	BackupDir                  string `yaml:"backup_dir"`
 	FullBackupCronSchedule     string `yaml:"full_backup_cron_schedule"`
 	IncrementalBackupInMinutes int    `yaml:"incremental_backup_in_minutes"`
+	PurgeBinlogAfterMinutes    int    `yaml:"purge_binlog_after_minutes"`
 	EnableInitRestore          bool   `yaml:"enable_init_restore"`
 	EnableRestoreOnDBFailure   bool   `yaml:"enable_restore_on_db_failure"`
 }

--- a/pkg/database/mariadb.go
+++ b/pkg/database/mariadb.go
@@ -286,7 +286,7 @@ func (m *MariaDB) StartIncBackup(ctx context.Context, mp LogPosition, dir string
 	if err != nil {
 		return fmt.Errorf("Cannot start binlog stream: %w", err)
 	}
-	m.flushTimer = time.AfterFunc(time.Duration(m.cfg.Backup.IncrementalBackupInMinutes)*time.Minute, func() { m.flushLogs("") })
+	m.flushTimer = time.AfterFunc(time.Duration(m.cfg.Backup.PurgeBinlogAfterMinutes)*time.Minute, func() { m.flushLogs("") })
 	for {
 		ev, inerr := streamer.GetEvent(ctx)
 		if inerr != nil {
@@ -325,11 +325,11 @@ func (m *MariaDB) StartIncBackup(ctx context.Context, mp LogPosition, dir string
 		switch ev.Event.(type) {
 		case *replication.RowsEvent:
 			if m.flushTimer == nil {
-				m.flushTimer = time.AfterFunc(time.Duration(m.cfg.Backup.IncrementalBackupInMinutes)*time.Minute, func() { m.flushLogs(binlogFile) })
+				m.flushTimer = time.AfterFunc(time.Duration(m.cfg.Backup.PurgeBinlogAfterMinutes)*time.Minute, func() { m.flushLogs(binlogFile) })
 			}
 		case *replication.QueryEvent:
 			if m.flushTimer == nil {
-				m.flushTimer = time.AfterFunc(time.Duration(m.cfg.Backup.IncrementalBackupInMinutes)*time.Minute, func() { m.flushLogs(binlogFile) })
+				m.flushTimer = time.AfterFunc(time.Duration(m.cfg.Backup.PurgeBinlogAfterMinutes)*time.Minute, func() { m.flushLogs(binlogFile) })
 			}
 		}
 


### PR DESCRIPTION
With large databases it can be that the initial restore takes longer
than one incremental backup. If the binlog streaming runs in a parallel
pod to the backup it can be that the binlog file has already been purged
before backup is restored and the syncing starts.