### PR TITLE
Changes binlog flushing and purging behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ namespace: # k8s namespace name
 sidecar: # boolean
 backup:
   full_backup_interval_in_hours: # Interval for full MariaDB dumps in hours
-  incremental_backup_interval_in_minutes: # Interval for saving incremental backups
+  incremental_backup_interval_in_minutes: # Interval for saving incremental backups, one continous increment if < 0
+  purge_binlog_after_minutes: # if > 0 binlog files are kept on the primary db until they are older 
   enable_init_restore: # Enables a automatic restore if one of the databases (in MariaDB.databases) are missing.
   enable_restore_on_db_failure: # Enables automatic restore if the db is unhealthy.\
+  disable_binlog_purge_on_rotate: # Boolean to disable binlog purging. Purging is enabled by detault
   outh:
     enabled: # enables OAuth to access the API (openID)\
     provider_url: # Url of the openID provider (e.g. Dex)\

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,7 +60,7 @@ type BackupService struct {
 	PurgeBinlogAfterMinutes    int    `yaml:"purge_binlog_after_minutes"`
 	EnableInitRestore          bool   `yaml:"enable_init_restore"`
 	EnableRestoreOnDBFailure   bool   `yaml:"enable_restore_on_db_failure"`
-	EnableBinlogPurgeOnRotate  bool   `yaml:"enable_binlog_purge_on_rotate"`
+	DisableBinlogPurgeOnRotate bool   `yaml:"disable_binlog_purge_on_rotate"`
 }
 
 // DatabaseConfig holds info for the database to back up

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,8 +57,10 @@ type BackupService struct {
 	BackupDir                  string `yaml:"backup_dir"`
 	FullBackupCronSchedule     string `yaml:"full_backup_cron_schedule"`
 	IncrementalBackupInMinutes int    `yaml:"incremental_backup_in_minutes"`
+	PurgeBinlogAfterMinutes    int    `yaml:"purge_binlog_after_minutes"`
 	EnableInitRestore          bool   `yaml:"enable_init_restore"`
 	EnableRestoreOnDBFailure   bool   `yaml:"enable_restore_on_db_failure"`
+	EnableBinlogPurgeOnRotate  bool   `yaml:"enable_binlog_purge_on_rotate"`
 }
 
 // DatabaseConfig holds info for the database to back up

--- a/pkg/database/mariadb.go
+++ b/pkg/database/mariadb.go
@@ -384,8 +384,18 @@ func (m *MariaDB) flushLogs(binlogFile string) (err error) {
 		return
 	}
 
-	if binlogFile != "" {
-		return purgeBinlogsTo(m.cfg.Database, binlogFile)
+	if m.cfg.Backup.EnableBinlogPurgeOnRotate {
+		if m.cfg.Backup.PurgeBinlogAfterMinutes > 0 {
+			err = purgeBinlogsBefore(m.cfg.Database, m.cfg.Backup.PurgeBinlogAfterMinutes)
+			if err != nil {
+				log.Warn("error purging binlogs: ", err)
+			}
+		} else if binlogFile != "" {
+			err = purgeBinlogsTo(m.cfg.Database, binlogFile)
+			if err != nil {
+				log.Warn("error purging binlogs: ", err)
+			}
+		}
 	}
 	return
 }

--- a/pkg/database/mariadb.go
+++ b/pkg/database/mariadb.go
@@ -286,7 +286,9 @@ func (m *MariaDB) StartIncBackup(ctx context.Context, mp LogPosition, dir string
 	if err != nil {
 		return fmt.Errorf("Cannot start binlog stream: %w", err)
 	}
-	m.flushTimer = time.AfterFunc(time.Duration(m.cfg.Backup.IncrementalBackupInMinutes)*time.Minute, func() { m.flushLogs("") })
+	if m.cfg.Backup.IncrementalBackupInMinutes > 0 {
+		m.flushTimer = time.AfterFunc(time.Duration(m.cfg.Backup.IncrementalBackupInMinutes)*time.Minute, func() { m.flushLogs("") })
+	}
 	for {
 		ev, inerr := streamer.GetEvent(ctx)
 		if inerr != nil {
@@ -324,11 +326,11 @@ func (m *MariaDB) StartIncBackup(ctx context.Context, mp LogPosition, dir string
 
 		switch ev.Event.(type) {
 		case *replication.RowsEvent:
-			if m.flushTimer == nil {
+			if m.flushTimer == nil && m.cfg.Backup.IncrementalBackupInMinutes > 0 {
 				m.flushTimer = time.AfterFunc(time.Duration(m.cfg.Backup.IncrementalBackupInMinutes)*time.Minute, func() { m.flushLogs(binlogFile) })
 			}
 		case *replication.QueryEvent:
-			if m.flushTimer == nil {
+			if m.flushTimer == nil && m.cfg.Backup.IncrementalBackupInMinutes > 0 {
 				m.flushTimer = time.AfterFunc(time.Duration(m.cfg.Backup.IncrementalBackupInMinutes)*time.Minute, func() { m.flushLogs(binlogFile) })
 			}
 		}

--- a/pkg/database/mariadb.go
+++ b/pkg/database/mariadb.go
@@ -384,7 +384,7 @@ func (m *MariaDB) flushLogs(binlogFile string) (err error) {
 		return
 	}
 
-	if m.cfg.Backup.EnableBinlogPurgeOnRotate {
+	if !m.cfg.Backup.DisableBinlogPurgeOnRotate {
 		if m.cfg.Backup.PurgeBinlogAfterMinutes > 0 {
 			err = purgeBinlogsBefore(m.cfg.Database, m.cfg.Backup.PurgeBinlogAfterMinutes)
 			if err != nil {


### PR DESCRIPTION
With this change the rotation of binlog files has been made optional. The binlog can still rotate if the binlog file on the server is bigger than [max_binlog_size](https://mariadb.com/kb/en/replication-and-binary-log-system-variables/#max_binlog_size).
Also binlog purging has been made optional and can be set to delete binlog files older than `purge_binlog_after_minutes`

Changed:
- binlog is only rotated if `incremental_backup_in_minutes` > 0

New: 
- disables binlog purging on binlog rotation with `disable_binlog_purge_on_rotate`
- `purge_binlog_after_minutes`: if binlog purging is not disabled, it will purge binlog older than x minutes at the time of rotation
