### PR TITLE
Improves verify process; makes restore folder configurable

### DIFF
--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -63,7 +63,7 @@ func main() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGSTOP)
 
-	sm, err := storage.NewManager(cfg.Storages, cfg.ServiceName, cfg.Database.LogNameFormat)
+	sm, err := storage.NewManager(cfg.Storages, cfg.ServiceName, cfg.Backup.RestoreDir, cfg.Database.LogNameFormat)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -178,7 +178,7 @@ func GetRestore(m *backup.Manager) echo.HandlerFunc {
 //PostRestoreDownload handles restore download requests
 func PostRestoreDownload(m *backup.Manager) echo.HandlerFunc {
 	return func(c echo.Context) (err error) {
-		os.RemoveAll(constants.RESTOREFOLDER)
+		os.RemoveAll(path.Join(m.GetConfig().Backup.RestoreDir, m.GetConfig().ServiceName))
 		res := c.Response()
 		params, err := c.FormParams()
 		res.WriteHeader(http.StatusOK)

--- a/pkg/backup/manager_test.go
+++ b/pkg/backup/manager_test.go
@@ -132,9 +132,9 @@ func TestManagerIncbackErrorHandling(t *testing.T) {
 
 func TestManagerStorageErrorHandling(t *testing.T) {
 	m, _, cfg := setup(t)
-	s1 := storage.NewMockStorage(cfg, "s1", "log")
+	s1 := storage.NewMockStorage(cfg, "s1", "./restore", "log")
 	s1.WithError(true)
-	s2 := storage.NewMockStorage(cfg, "s2", "log")
+	s2 := storage.NewMockStorage(cfg, "s2", "./restore", "log")
 	m.Storage.AddStorage(s1)
 	m.Storage.AddStorage(s2)
 
@@ -170,9 +170,9 @@ func setup(t *testing.T) (m *Manager, db *database.MockDB, cfg config.Config) {
 			Type: "mock",
 		},
 	}
-	s1 := storage.NewMockStorage(cfg, "s1", "log")
-	s2 := storage.NewMockStorage(cfg, "s2", "log")
-	sm, err := storage.NewManager(cfg.Storages, "test", "")
+	s1 := storage.NewMockStorage(cfg, "s1", "./restore", "log")
+	s2 := storage.NewMockStorage(cfg, "s2", "./restore", "log")
+	sm, err := storage.NewManager(cfg.Storages, "test", "./restore", "")
 	if err != nil {
 		t.Errorf("expected storage instance, but got error: %s.", err.Error())
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,6 +55,7 @@ type BackupService struct {
 	Version                    string `yaml:"version"`
 	OAuth                      OAuth  `yaml:"oauth"`
 	BackupDir                  string `yaml:"backup_dir"`
+	RestoreDir                 string `yaml:"restore_dir"`
 	FullBackupCronSchedule     string `yaml:"full_backup_cron_schedule"`
 	IncrementalBackupInMinutes int    `yaml:"incremental_backup_in_minutes"`
 	PurgeBinlogAfterMinutes    int    `yaml:"purge_binlog_after_minutes"`
@@ -145,8 +146,8 @@ type OAuth struct {
 
 // VerificationService holds info for the backup verification service
 type VerificationService struct {
-	IntervalInMinutes int `yaml:"interval_in_minutes"`
-	MariaDBVersion    string
+	RunAfterIncBackups int `yaml:"run_after_inc_backups"`
+	MariaDBVersion     string
 }
 
 // GetConfig returns the config struct from a yaml file

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -39,6 +39,4 @@ const (
 	POSTGRESDEPLOYMENT = "k8s_postgres_deployment.yaml"
 	// POSTGRESSERIVCE path to postgres k8s service file
 	POSTGRESSERIVCE = "k8s_postgres_svc.yaml"
-	// RESTOREFOLDER path to database restore folder
-	RESTOREFOLDER = "/restore"
 )

--- a/pkg/storage/disk.go
+++ b/pkg/storage/disk.go
@@ -181,6 +181,11 @@ func (d *Disk) GetFullBackups() (bl []Backup, err error) {
 	return bl, err
 }
 
+// GetTotalIncBackupsFromDump implements interface
+func (d *Disk) GetTotalIncBackupsFromDump(key string) (t int, err error) {
+	return
+}
+
 // GetIncBackupsFromDump implements interface
 func (d *Disk) GetIncBackupsFromDump(key string) (bl []Backup, err error) {
 

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -30,6 +30,8 @@ type Storage interface {
 	GetStatusError() map[string]string
 	// GetStatusErrorByKey returns error per backup
 	GetStatusErrorByKey(backupKey string) string
+	// GetTotalIncBackupsFromDump returns current total incremental backups in this dump
+	GetTotalIncBackupsFromDump(key string) (t int, err error)
 }
 
 // ChannelWriter for storages that do not support consuming io.Reader

--- a/pkg/storage/manager.go
+++ b/pkg/storage/manager.go
@@ -28,17 +28,17 @@ func init() {
 }
 
 // NewManager creates a new manager instance
-func NewManager(c config.StorageService, serviceName, binLog string) (m *Manager, err error) {
+func NewManager(c config.StorageService, serviceName, restoreFolder, binLog string) (m *Manager, err error) {
 	stsvc := make(map[string]Storage)
 	for _, cfg := range c.Swift {
-		swift, err := NewSwift(cfg, serviceName, binLog)
+		swift, err := NewSwift(cfg, serviceName, restoreFolder, binLog)
 		if err != nil {
 			return m, err
 		}
 		stsvc[cfg.Name] = swift
 	}
 	for _, cfg := range c.S3 {
-		s3, err := NewS3(cfg, serviceName, binLog)
+		s3, err := NewS3(cfg, serviceName, restoreFolder, binLog)
 		if err != nil {
 			return m, err
 		}
@@ -71,6 +71,11 @@ func NewManager(c config.StorageService, serviceName, binLog string) (m *Manager
 // AddStorage can add a specific storage service
 func (m *Manager) AddStorage(s Storage) {
 	m.storageServices[s.GetStorageServiceName()] = s
+}
+
+// GetStorage returns a specific storage service
+func (m *Manager) GetStorage(s string) Storage {
+	return m.storageServices[s]
 }
 
 // GetStorageServicesKeys returns a list of all storage names

--- a/pkg/storage/mariadb.go
+++ b/pkg/storage/mariadb.go
@@ -151,6 +151,11 @@ func (m *MariaDBStream) GetStatusErrorByKey(backupKey string) string {
 	return ""
 }
 
+// GetTotalIncBackupsFromDump implements interface
+func (m *MariaDBStream) GetTotalIncBackupsFromDump(key string) (t int, err error) {
+	return
+}
+
 // WriteFolder implements interface
 func (m *MariaDBStream) WriteFolder(p string) (err error) {
 

--- a/pkg/storage/mockStorage.go
+++ b/pkg/storage/mockStorage.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"io"
+	"path"
 
 	"github.com/sapcc/maria-back-me-up/pkg/config"
 )
@@ -32,12 +33,13 @@ type MockStorage struct {
 }
 
 // NewMockStorage creates a mock storage instance
-func NewMockStorage(c config.Config, serviceName, binLog string) (m *MockStorage) {
+func NewMockStorage(c config.Config, serviceName, restoreFolder, binLog string) (m *MockStorage) {
 	m = &MockStorage{}
 	m.binLog = binLog
 	m.cfg = c
 	m.serviceName = serviceName
 	m.withError = false
+	m.restoreFolder = path.Join(restoreFolder, serviceName)
 
 	return
 }
@@ -59,6 +61,10 @@ func (s *MockStorage) GetFullBackups() (bl []Backup, err error) {
 
 // DownloadLatestBackup implements interface
 func (s *MockStorage) DownloadLatestBackup() (path string, err error) {
+	return
+}
+
+func (s *MockStorage) GetTotalIncBackupsFromDump(key string) (t int, err error) {
 	return
 }
 

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -32,7 +32,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/sapcc/maria-back-me-up/pkg/config"
-	"github.com/sapcc/maria-back-me-up/pkg/constants"
 	"github.com/sapcc/maria-back-me-up/pkg/log"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -54,7 +53,7 @@ type (
 )
 
 // NewS3 creates a s3 storage instance
-func NewS3(c config.S3, serviceName, binLog string) (s3 *S3, err error) {
+func NewS3(c config.S3, serviceName, restoreFolder, binLog string) (s3 *S3, err error) {
 	s, err := session.NewSession(&aws.Config{
 		Endpoint:         aws.String(c.AwsEndpoint),
 		Region:           aws.String(c.Region),
@@ -69,7 +68,7 @@ func NewS3(c config.S3, serviceName, binLog string) (s3 *S3, err error) {
 		cfg:           c,
 		session:       s,
 		serviceName:   serviceName,
-		restoreFolder: path.Join(constants.RESTOREFOLDER, c.Name),
+		restoreFolder: path.Join(restoreFolder, serviceName),
 		logger:        logger.WithField("service", serviceName),
 		binLog:        binLog,
 		statusError:   make(map[string]string, 0),
@@ -168,6 +167,22 @@ func (s *S3) DownloadBackupWithLogPosition(fullBackupPath, binlog string) (path 
 		}
 	}
 	path = filepath.Join(s.restoreFolder, fullBackupPath)
+	return
+}
+
+// GetTotalIncBackupsFromDump implements interface
+func (s *S3) GetTotalIncBackupsFromDump(key string) (t int, err error) {
+	t = 0
+	svc := s3.New(s.session)
+	list, err := svc.ListObjectsV2(&s3.ListObjectsV2Input{Bucket: aws.String(s.cfg.BucketName), Prefix: aws.String(strings.Replace(key, "dump.tar", "", -1))})
+	if err != nil {
+		return t, s.handleError("", err)
+	}
+	for _, incObj := range list.Contents {
+		if !strings.HasSuffix(*incObj.Key, "/") && strings.Contains(*incObj.Key, s.binLog) {
+			t++
+		}
+	}
 	return
 }
 

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -68,7 +68,7 @@ func NewS3(c config.S3, serviceName, restoreFolder, binLog string) (s3 *S3, err 
 		cfg:           c,
 		session:       s,
 		serviceName:   serviceName,
-		restoreFolder: path.Join(restoreFolder, serviceName),
+		restoreFolder: path.Join(restoreFolder, c.Name),
 		logger:        logger.WithField("service", serviceName),
 		binLog:        binLog,
 		statusError:   make(map[string]string, 0),

--- a/pkg/storage/swift.go
+++ b/pkg/storage/swift.go
@@ -49,7 +49,7 @@ func NewSwift(c config.Swift, serviceName, restoreFolder, logBin string) (s *Swi
 		cfg:           c,
 		connection:    conn,
 		serviceName:   serviceName,
-		restoreFolder: path.Join(restoreFolder, serviceName),
+		restoreFolder: path.Join(restoreFolder, c.Name),
 		logger:        logger.WithField("service", serviceName),
 		logBin:        logBin,
 		statusError:   make(map[string]string, 0),

--- a/pkg/storage/swift.go
+++ b/pkg/storage/swift.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ncw/swift"
 	"github.com/sapcc/maria-back-me-up/pkg/config"
-	"github.com/sapcc/maria-back-me-up/pkg/constants"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
@@ -30,7 +29,7 @@ type Swift struct {
 }
 
 // NewSwift creates a swift storage instance
-func NewSwift(c config.Swift, serviceName string, logBin string) (s *Swift, err error) {
+func NewSwift(c config.Swift, serviceName, restoreFolder, logBin string) (s *Swift, err error) {
 	conn := &swift.Connection{
 		AuthVersion:  c.AuthVersion,
 		AuthUrl:      c.AuthURL,
@@ -50,7 +49,7 @@ func NewSwift(c config.Swift, serviceName string, logBin string) (s *Swift, err 
 		cfg:           c,
 		connection:    conn,
 		serviceName:   serviceName,
-		restoreFolder: path.Join(constants.RESTOREFOLDER, c.Name),
+		restoreFolder: path.Join(restoreFolder, serviceName),
 		logger:        logger.WithField("service", serviceName),
 		logBin:        logBin,
 		statusError:   make(map[string]string, 0),
@@ -73,6 +72,21 @@ func (s *Swift) GetStatusErrorByKey(backupKey string) string {
 		return st
 	}
 	return ""
+}
+
+// GetTotalIncBackupsFromDump implements interface
+func (s *Swift) GetTotalIncBackupsFromDump(key string) (t int, err error) {
+	t = 0
+	objs, err := s.connection.ObjectsAll(s.cfg.ContainerName, &swift.ObjectsOpts{Prefix: strings.Replace(key, "dump.tar", "", -1)})
+	if err != nil {
+		return t, s.handleError("", err)
+	}
+	for _, o := range objs {
+		if !strings.HasSuffix(o.Name, "/") && strings.Contains(o.Name, s.logBin) {
+			t++
+		}
+	}
+	return
 }
 
 // WriteFolder implements interface

--- a/pkg/test/setup.go
+++ b/pkg/test/setup.go
@@ -102,7 +102,7 @@ func Setup(t *testing.T, opts *SetupOptions) (m *backup.Manager, cfg config.Conf
 		}}
 	}
 
-	s, err := storage.NewManager(cfg.Storages, cfg.ServiceName, cfg.Database.LogNameFormat)
+	s, err := storage.NewManager(cfg.Storages, cfg.ServiceName, "./restore", cfg.Database.LogNameFormat)
 	if err != nil {
 		t.Errorf("could not setup manager: %v", err.Error())
 		t.FailNow()

--- a/pkg/verification/manager.go
+++ b/pkg/verification/manager.go
@@ -40,7 +40,7 @@ func NewManager(c config.Config) (m *Manager, err error) {
 		return
 	}
 
-	stgM, err := storage.NewManager(c.Storages, c.ServiceName, db.GetLogPosition().Format)
+	stgM, err := storage.NewManager(c.Storages, c.ServiceName, c.Backup.RestoreDir, db.GetLogPosition().Format)
 	if err != nil {
 		return
 	}
@@ -50,7 +50,7 @@ func NewManager(c config.Config) (m *Manager, err error) {
 			logger.Warnf("cannot create verification for %s", st)
 			continue
 		}
-		v := NewVerification(c.ServiceName, st, stgM, c.Verification, db, k8sm)
+		v := NewVerification(c.ServiceName, stgM.GetStorage(st), c.Verification, db, k8sm)
 		if err != nil {
 			return m, err
 		}
@@ -72,7 +72,7 @@ func NewManager(c config.Config) (m *Manager, err error) {
 // Start a verification routine per storage
 func (m *Manager) Start(ctx context.Context) {
 	for _, v := range m.verifications {
-		logger.Debugf("starting verification for %s backup", v.storageServiceName)
+		logger.Debugf("starting verification for %s backup", v.storage.GetStorageServiceName())
 		go v.Start(ctx)
 	}
 }

--- a/pkg/verification/status.go
+++ b/pkg/verification/status.go
@@ -87,7 +87,7 @@ func (s *Status) Reset() {
 }
 
 // Upload the status info to the specified storage service
-func (s *Status) Upload(restoreFolder, logNameFormat, serviceName string, manager *storage.Manager) {
+func (s *Status) Upload(restoreFolder, logNameFormat, serviceName string, st storage.Storage) {
 	s.RLock()
 	out, err := yaml.Marshal(s)
 	s.RUnlock()
@@ -102,7 +102,7 @@ func (s *Status) Upload(restoreFolder, logNameFormat, serviceName string, manage
 		file = file + "/verify_fail.yaml"
 	}
 	s.logger.Debug("Uploading verify status to: ", file)
-	err = manager.WriteStream(s.StorageService, file, "", bytes.NewReader(out), nil, false)
+	err = st.WriteStream(file, "", bytes.NewReader(out), nil, false)
 	if err != nil {
 		s.logger.Error(fmt.Errorf("cannot upload verify status: %s", err.Error()))
 	}
@@ -126,7 +126,7 @@ func (s *Status) Upload(restoreFolder, logNameFormat, serviceName string, manage
 		base := path.Base(restoreFolder)
 		tags["key"] = path.Join(serviceName, base)
 		tags["binlog"] = fmt.Sprintf("%s.%d", logNameFormat, binlogNumber)
-		err = manager.WriteStream(s.StorageService, storage.LastSuccessfulBackupFile, "", strings.NewReader("latest_backup"), tags, false)
+		err = st.WriteStream(storage.LastSuccessfulBackupFile, "", strings.NewReader("latest_backup"), tags, false)
 		if err != nil {
 			s.logger.Error(fmt.Errorf("cannot upload verify status: %s", err.Error()))
 		}


### PR DESCRIPTION
- Verify process now runs after X incremental backups and not after a specific time, since there is no point in verifying a backup if nothing has changed. Some services do not update the database very often.
- The restore folder is now configurable to be able to use a pvc in k8s
