### PR TITLE
updates alpine to 3.22.0; drops mysql-utilities (only python2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,37 +4,40 @@ RUN apk add --no-cache make git
 COPY . /src
 RUN make -C /src install PREFIX=/pkg GO_BUILDFLAGS='-mod vendor'
 
-FROM keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/alpine:3.15.9
+FROM keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/alpine:3.22.0
 LABEL maintainer="Stefan Hipfel <stefan.hipfel@sap.com>"
 LABEL source_repository="https://github.com/sapcc/maria-back-me-up"
 
-ENV PACKAGES="mysql-client mariadb curl python2" \
-    LIB_PACKAGES="glib-dev mariadb-dev zlib-dev pcre-dev libressl-dev" \
-    BUILD_PACKAGES="cmake build-base git" \
-    BUILD_PATH="/opt/mydumper-src/"
+ARG MYDUMPER_CMAKE_ARGS="-DWITH_ZSTD=ON"
+ARG MYDUMPER_VERSION="v0.19.1-3"
 
-RUN apk --no-cache add \
-    $PACKAGES \
-    $BUILD_PACKAGES \
-    $LIB_PACKAGES \
+# libressl-dev has problems with openssl-dev
+ENV PACKAGES="openssh-client ca-certificates bash curl gzip openssl mysql-client " \
+    LIB_PACKAGES="glib-dev mariadb-dev zlib-dev pcre-dev gcompat" \
+    BUILD_PACKAGES="cmake build-base git" \
+    MYDUMPER_BUILD_PATH="/opt/mydumper-src/"
+
+ADD "https://github.com/mydumper/mydumper/archive/refs/tags/${MYDUMPER_VERSION}.tar.gz" /tmp/mydumper.tar.gz
+RUN apk --no-cache --verbose add \
+          ${PACKAGES} \
+          ${BUILD_PACKAGES} \
+          ${LIB_PACKAGES} \
     && \
-    git clone https://github.com/maxbube/mydumper.git $BUILD_PATH && \
-    cd $BUILD_PATH && \
-    git checkout 2cdd78599ea7e13f36c6e8a09051814f6bd1564a && \
-    cmake . && \
+    mkdir -p ${MYDUMPER_BUILD_PATH} && \
+    tar --strip-components=1 -xzvf /tmp/mydumper.tar.gz -C ${MYDUMPER_BUILD_PATH} && \
+    rm /tmp/mydumper.tar.gz && \
+    cd ${MYDUMPER_BUILD_PATH} && \
+    cmake . "${MYDUMPER_CMAKE_ARGS}" && \
     make && \
-    mv ./mydumper /usr/bin/. && \
-    mv ./myloader /usr/bin/. && \
-    cd / && rm -rf $BUILD_PATH && \
-    apk del $BUILD_PACKAGES && \
+    mv ./mydumper /usr/local/bin/. && \
+    mv ./myloader /usr/local/bin/. && \
+    cd / && rm -rf ${MYDUMPER_BUILD_PATH} \
+    && \
+    # Clean up
+    apk del ${BUILD_PACKAGES} && \
     rm -f /usr/lib/*.a && \
     (rm "/tmp/"* 2>/dev/null || true) && \
     (rm -rf /var/cache/apk/* 2>/dev/null || true)
-
-ADD mysql-utilities-1.6.5.tar.gz /tmp/
-WORKDIR /tmp/mysql-utilities-1.6.5/
-RUN python2 setup.py install
-RUN rm -rf /tmp/mysql-utilities-1.6.5/
 
 WORKDIR /
 RUN curl -Lo /bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \


### PR DESCRIPTION
need to drop mysql-utilities, since it is deprecated and only available for python2 (which is not available for alpine 3.22)
mysql-utilities has to my knowledge only been used for the validation part, which is no longer in use.

