### PR TITLE
install mariadb into maria-back-me up image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG MYDUMPER_CMAKE_ARGS="-DWITH_ZSTD=ON"
 ARG MYDUMPER_VERSION="v0.19.1-3"
 
 # libressl-dev has problems with openssl-dev
-ENV PACKAGES="openssh-client ca-certificates bash curl gzip openssl mysql-client " \
+ENV PACKAGES="openssh-client ca-certificates bash curl gzip openssl mariadb-client mariadb" \
     LIB_PACKAGES="glib-dev mariadb-dev zlib-dev pcre-dev gcompat" \
     BUILD_PACKAGES="cmake build-base git" \
     MYDUMPER_BUILD_PATH="/opt/mydumper-src/"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.5'
 services:
   db_prod:
-    image: mariadb:10.4.12
+    image: mariadb:10.11.13
     restart: on-failure
     environment:
       MYSQL_ROOT_PASSWORD: pw
@@ -12,7 +12,7 @@ services:
       - ./db_prod:/var/lib/mysql
 
   db_backup:
-    image: mariadb:10.4.12
+    image: mariadb:10.11.13
     restart: on-failure
     environment:
       MYSQL_ROOT_PASSWORD: pw

--- a/pkg/database/mariadb.go
+++ b/pkg/database/mariadb.go
@@ -544,9 +544,9 @@ func (m *MariaDB) restoreIncBackup(p string) (err error) {
 	if len(binlogFiles) == 0 {
 		return
 	}
-	log.Debug("start mysqlbinlog", binlogFiles)
+	log.Debug("start mariadb-binlog", binlogFiles)
 	binlogCMD := exec.Command(
-		"mysqlbinlog", binlogFiles...,
+		"mariadb-binlog", binlogFiles...,
 	)
 	mysqlPipe := exec.Command(
 		"mariadb",
@@ -565,7 +565,7 @@ func (m *MariaDB) restoreIncBackup(p string) (err error) {
 		return
 	}
 	if err = binlogCMD.Run(); err != nil {
-		return fmt.Errorf("mysqlbinlog error: %s", err.Error())
+		return fmt.Errorf("mariadb-binlog error: %s", err.Error())
 	}
 	return mysqlPipe.Wait()
 }


### PR DESCRIPTION
* mariadb-binlog is required for incremental backup restore, and this tool is present in mariadb package, not mariadb-client

* use mariadb-binlog command instead of mysqlbinlog

* update docker-compose to use modern mariadb release