### PR TITLE
Don't use gtid-strict-mode in mariadb-binlog restore

### DIFF
--- a/pkg/database/mariadb.go
+++ b/pkg/database/mariadb.go
@@ -545,9 +545,8 @@ func (m *MariaDB) restoreIncBackup(p string) (err error) {
 		return
 	}
 	log.Debug("start mariadb-binlog", binlogFiles)
-	binlogCMD := exec.Command(
-		"mariadb-binlog", binlogFiles...,
-	)
+	binlogArgs := append([]string{"--skip-gtid-strict-mode"}, binlogFiles...)
+	binlogCMD := exec.Command("mariadb-binlog", binlogArgs...)
 	mysqlPipe := exec.Command(
 		"mariadb",
 		"--skip-ssl",


### PR DESCRIPTION
Don't use gtid-strict-mode in mariadb-binlog. It's enabled by default in mariadb-binlog, but disabled in mariadb-server, so having this option enabled leads to the following error, when replaying from multiple (>1) binlog files:

```
ERROR: Binary logs are missing data for domain 0.
Expected data to start from state 0-0-0;
however, the initial GTID state of the logs was 0-1-406690.
```