### PR TITLE
(fix) partial storage failure no longer triggers full backup restart

### DIFF
--- a/pkg/backup/manager.go
+++ b/pkg/backup/manager.go
@@ -269,8 +269,8 @@ func (m *Manager) handleBackupError(err error, backup map[string]int) error {
 		return m.Db.Restore(bf)
 	}
 
-	merr, ok := err.(*multierror.Error)
-	if !ok {
+	var merr *multierror.Error
+	if !errors.As(err, &merr) {
 		return err
 	}
 
@@ -326,12 +326,8 @@ func (m *Manager) onBinlogRotation(c chan error) {
 			continue
 		}
 		stsError := make([]string, 0)
-		merr, ok := err.(*multierror.Error)
-		if merr != nil {
-			if !ok {
-				m.setUpdateStatus(m.updateSts.IncBackup, m.Storage.GetStorageServicesKeys(), false)
-				logger.Errorf("unknown error: %s", merr.Error())
-			}
+		var merr *multierror.Error
+		if errors.As(err, &merr) {
 			if len(merr.Errors) > 0 {
 				for i := 0; i < len(merr.Errors); i++ {
 					switch e := merr.Errors[i].(type) {
@@ -348,6 +344,9 @@ func (m *Manager) onBinlogRotation(c chan error) {
 				}
 			}
 			m.setUpdateStatus(m.updateSts.IncBackup, stsError, false)
+		} else {
+			m.setUpdateStatus(m.updateSts.IncBackup, m.Storage.GetStorageServicesKeys(), false)
+			logger.Errorf("unknown error: %s", err.Error())
 		}
 	}
 }

--- a/pkg/database/mockdb.go
+++ b/pkg/database/mockdb.go
@@ -5,6 +5,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -45,6 +46,10 @@ func (m *MockDB) CreateFullBackup(path string) (bp LogPosition, err error) {
 		err = &dberror.DatabaseMissingError{}
 		return bp, err
 	}
+	// Match real CreateFullBackup behavior where err gets wrapped by errors.Join
+	defer func() {
+		err = errors.Join(err, nil)
+	}()
 	return bp, m.storage.WriteFolderAll(path)
 }
 


### PR DESCRIPTION
When only some storage backends fail, the backup should continue with
the remaining ones. A wrapped error type prevented this, causing the
entire backup cycle to restart unnecessarily.