### PR TITLE
feat(s3): configurable object lock on uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ List of features currently available:
   - S3
   - Swift
   - Disk
+- Immutable backups via S3 Object Lock (COMPLIANCE mode: no one, including root, can delete objects before retention expires)
 - Automatic verification of existing backups (can be run as separate service)
 - UI to see and select an available backup to restore to
 - UI shows status of backup verification
@@ -141,6 +142,9 @@ storages:
       sse_customer_key:
       region: # s3 region
       bucket_name: # bucket name to save the backup to
+      object_lock_enabled: # default false. Set S3 Object Lock on every uploaded object. Requires a bucket with Object Lock enabled; if the bucket doesn't support it, uploads continue without lock and a warning is logged
+      object_lock_mode: # COMPLIANCE (default) or GOVERNANCE
+      object_lock_retention_days: # required when enabled: per-object lock duration in days. Overrides any bucket default retention rule
   swift:
     - name: # name of the storage
       auth_version: # OpenStack auth version

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"go.yaml.in/yaml/v2"
 )
@@ -80,16 +81,19 @@ type StorageService struct {
 
 // S3 hols info for the AWS S3 storage service
 type S3 struct {
-	Name                 string  `yaml:"name"`
-	Verify               *bool   `yaml:"verify"`
-	AwsAccessKeyID       string  `yaml:"aws_access_key_id"`
-	AwsSecretAccessKey   string  `yaml:"aws_secret_access_key"`
-	AwsEndpoint          string  `yaml:"aws_endpoint"`
-	SSECustomerAlgorithm *string `yaml:"sse_customer_algorithm"`
-	S3ForcePathStyle     *bool   `yaml:"s3_force_path_style"`
-	SSECustomerKey       *string `yaml:"sse_customer_key"`
-	Region               string  `yaml:"region"`
-	BucketName           string  `yaml:"bucket_name"`
+	Name                    string  `yaml:"name"`
+	Verify                  *bool   `yaml:"verify"`
+	AwsAccessKeyID          string  `yaml:"aws_access_key_id"`
+	AwsSecretAccessKey      string  `yaml:"aws_secret_access_key"`
+	AwsEndpoint             string  `yaml:"aws_endpoint"`
+	SSECustomerAlgorithm    *string `yaml:"sse_customer_algorithm"`
+	S3ForcePathStyle        *bool   `yaml:"s3_force_path_style"`
+	SSECustomerKey          *string `yaml:"sse_customer_key"`
+	Region                  string  `yaml:"region"`
+	BucketName              string  `yaml:"bucket_name"`
+	ObjectLockEnabled       bool    `yaml:"object_lock_enabled"`
+	ObjectLockMode          string  `yaml:"object_lock_mode"`
+	ObjectLockRetentionDays int     `yaml:"object_lock_retention_days"`
 }
 
 // Swift holds info for the OS swift storage service
@@ -165,6 +169,10 @@ func GetConfig(opts Options) (cfg Config, err error) {
 
 	setDefaults(cfg)
 
+	if err = validate(cfg); err != nil {
+		return cfg, err
+	}
+
 	return cfg, nil
 }
 
@@ -179,4 +187,31 @@ func setDefaults(cfg Config) {
 			cfg.Storages.MariaDB[i].DumpFilterBufferSizeMB = 2
 		}
 	}
+
+	for i, s := range cfg.Storages.S3 {
+		if !s.ObjectLockEnabled {
+			continue
+		}
+		if s.ObjectLockMode == "" {
+			cfg.Storages.S3[i].ObjectLockMode = "COMPLIANCE"
+		} else {
+			cfg.Storages.S3[i].ObjectLockMode = strings.ToUpper(s.ObjectLockMode)
+		}
+	}
+}
+
+// validate checks config keys for invalid values
+func validate(cfg Config) error {
+	for _, s := range cfg.Storages.S3 {
+		if !s.ObjectLockEnabled {
+			continue
+		}
+		if s.ObjectLockMode != "COMPLIANCE" && s.ObjectLockMode != "GOVERNANCE" {
+			return fmt.Errorf("s3 %q: object_lock_mode must be COMPLIANCE or GOVERNANCE, got %q", s.Name, s.ObjectLockMode)
+		}
+		if s.ObjectLockRetentionDays <= 0 || s.ObjectLockRetentionDays > 36500 {
+			return fmt.Errorf("s3 %q: object_lock_retention_days must be between 1 and 36500", s.Name)
+		}
+	}
+	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import "testing"
+
+func TestObjectLockConfig(t *testing.T) {
+	cases := []struct {
+		name     string
+		s3       S3
+		wantMode string
+		wantErr  bool
+	}{
+		{
+			name:     "disabled by default ignores stale mode and days",
+			s3:       S3{Name: "s1", ObjectLockMode: "BOGUS", ObjectLockRetentionDays: -1},
+			wantMode: "BOGUS",
+		},
+		{
+			name:     "enabled defaults mode to compliance",
+			s3:       S3{Name: "s1", ObjectLockEnabled: true, ObjectLockRetentionDays: 30},
+			wantMode: "COMPLIANCE",
+		},
+		{
+			name:     "enabled normalizes mode case",
+			s3:       S3{Name: "s1", ObjectLockEnabled: true, ObjectLockMode: "governance", ObjectLockRetentionDays: 1},
+			wantMode: "GOVERNANCE",
+		},
+		{
+			name:    "enabled rejects unknown mode",
+			s3:      S3{Name: "s1", ObjectLockEnabled: true, ObjectLockMode: "BOGUS", ObjectLockRetentionDays: 30},
+			wantErr: true,
+		},
+		{
+			name:    "enabled requires retention days",
+			s3:      S3{Name: "s1", ObjectLockEnabled: true, ObjectLockMode: "COMPLIANCE"},
+			wantErr: true,
+		},
+		{
+			name:    "enabled rejects retention above 100 years",
+			s3:      S3{Name: "s1", ObjectLockEnabled: true, ObjectLockMode: "COMPLIANCE", ObjectLockRetentionDays: 40000},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{Storages: StorageService{S3: []S3{tc.s3}}}
+			setDefaults(cfg)
+			err := validate(cfg)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("want error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("want no error, got %v", err)
+			}
+			if got := cfg.Storages.S3[0].ObjectLockMode; got != tc.wantMode {
+				t.Errorf("mode: got %q, want %q", got, tc.wantMode)
+			}
+		})
+	}
+}

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -23,6 +24,7 @@ import (
 	tmtypes "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
 	"github.com/sapcc/maria-back-me-up/pkg/config"
 	"github.com/sapcc/maria-back-me-up/pkg/log"
 	"github.com/sirupsen/logrus"
@@ -40,6 +42,7 @@ type (
 		downloader    *transfermanager.Client
 		sseKey        *string
 		sseKeyMD5     *string
+		objectLock    bool
 		serviceName   string
 		restoreFolder string
 		logger        *logrus.Entry `yaml:"-"`
@@ -84,6 +87,20 @@ func NewS3(c config.S3, serviceName, restoreFolder, binLog string) (s3Storage *S
 
 	sseKey, sseKeyMD5 := encodeSSECustomerKey(c.SSECustomerKey)
 
+	objectLock := false
+	if c.ObjectLockEnabled {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		out, lockErr := client.GetObjectLockConfiguration(ctx,
+			&s3.GetObjectLockConfigurationInput{Bucket: aws.String(c.BucketName)})
+		objectLock = objectLockUsable(out, lockErr)
+		if lockErr != nil && !isObjectLockNotFound(lockErr) {
+			logger.Warnf("s3 %q: object lock probe on bucket %q failed, uploading without lock: %v", c.Name, c.BucketName, lockErr)
+		} else if !objectLock {
+			logger.Warnf("s3 %q: bucket %q has object lock disabled, uploading without lock", c.Name, c.BucketName)
+		}
+	}
+
 	return &S3{
 		cfg:           c,
 		client:        client,
@@ -91,6 +108,7 @@ func NewS3(c config.S3, serviceName, restoreFolder, binLog string) (s3Storage *S
 		downloader:    downloader,
 		sseKey:        sseKey,
 		sseKeyMD5:     sseKeyMD5,
+		objectLock:    objectLock,
 		serviceName:   serviceName,
 		restoreFolder: path.Join(restoreFolder, c.Name),
 		logger:        logger.WithField("service", serviceName),
@@ -109,6 +127,31 @@ func encodeSSECustomerKey(raw *string) (key, keyMD5 *string) {
 	digest := md5.Sum([]byte(*raw))
 	encodedMD5 := base64.StdEncoding.EncodeToString(digest[:])
 	return &encoded, &encodedMD5
+}
+
+// isObjectLockNotFound reports whether an error means the bucket has no
+// object lock configuration.
+func isObjectLockNotFound(err error) bool {
+	var ae smithy.APIError
+	return errors.As(err, &ae) && ae.ErrorCode() == "ObjectLockConfigurationNotFoundError"
+}
+
+// objectLockUsable reports whether a GetObjectLockConfiguration result confirms
+// the bucket accepts Object Lock headers.
+func objectLockUsable(out *s3.GetObjectLockConfigurationOutput, err error) bool {
+	if err != nil || out == nil || out.ObjectLockConfiguration == nil {
+		return false
+	}
+	return out.ObjectLockConfiguration.ObjectLockEnabled == types.ObjectLockEnabledEnabled
+}
+
+// objectLockParams returns per-upload Object Lock settings, zero-valued when disabled.
+func objectLockParams(c config.S3, now time.Time) (tmtypes.ObjectLockMode, *time.Time) {
+	if !c.ObjectLockEnabled {
+		return "", nil
+	}
+	t := now.Add(time.Duration(c.ObjectLockRetentionDays) * 24 * time.Hour)
+	return tmtypes.ObjectLockMode(c.ObjectLockMode), &t
 }
 
 // GetStorageServiceName implements interface
@@ -161,6 +204,10 @@ func (s *S3) WriteStream(fileName, mimeType string, body io.Reader, tags map[str
 		SSECustomerKey:       s.sseKey,
 		SSECustomerKeyMD5:    s.sseKeyMD5,
 		Tagging:              aws.String(tag.String()),
+	}
+
+	if s.objectLock {
+		input.ObjectLockMode, input.ObjectLockRetainUntilDate = objectLockParams(s.cfg, time.Now())
 	}
 
 	_, err := s.uploader.UploadObject(context.Background(), input)

--- a/pkg/storage/s3_test.go
+++ b/pkg/storage/s3_test.go
@@ -6,8 +6,17 @@ package storage
 import (
 	"crypto/md5"
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
+
+	tmtypes "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
+	"github.com/sapcc/maria-back-me-up/pkg/config"
 )
 
 func TestEncodeSSECustomerKey(t *testing.T) {
@@ -39,6 +48,123 @@ func TestEncodeSSECustomerKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestObjectLockParams(t *testing.T) {
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name      string
+		cfg       config.S3
+		wantMode  tmtypes.ObjectLockMode
+		wantUntil *time.Time
+	}{
+		{
+			name: "disabled ignores mode and days",
+			cfg:  config.S3{ObjectLockMode: "COMPLIANCE", ObjectLockRetentionDays: 30},
+		},
+		{
+			name:      "compliance 30 days",
+			cfg:       config.S3{ObjectLockEnabled: true, ObjectLockMode: "COMPLIANCE", ObjectLockRetentionDays: 30},
+			wantMode:  tmtypes.ObjectLockModeCompliance,
+			wantUntil: timePtr(now.Add(30 * 24 * time.Hour)),
+		},
+		{
+			name:      "governance 1 day",
+			cfg:       config.S3{ObjectLockEnabled: true, ObjectLockMode: "GOVERNANCE", ObjectLockRetentionDays: 1},
+			wantMode:  tmtypes.ObjectLockModeGovernance,
+			wantUntil: timePtr(now.Add(24 * time.Hour)),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotMode, gotUntil := objectLockParams(tc.cfg, now)
+			if gotMode != tc.wantMode {
+				t.Errorf("mode: got %q, want %q", gotMode, tc.wantMode)
+			}
+			if !equalTimePtr(gotUntil, tc.wantUntil) {
+				t.Errorf("retain until: got %v, want %v", gotUntil, tc.wantUntil)
+			}
+		})
+	}
+}
+
+func TestObjectLockUsable(t *testing.T) {
+	cases := []struct {
+		name string
+		out  *s3.GetObjectLockConfigurationOutput
+		err  error
+		want bool
+	}{
+		{
+			name: "enabled bucket",
+			out: &s3.GetObjectLockConfigurationOutput{
+				ObjectLockConfiguration: &types.ObjectLockConfiguration{ObjectLockEnabled: types.ObjectLockEnabledEnabled},
+			},
+			want: true,
+		},
+		{
+			name: "probe error",
+			err:  errors.New("ObjectLockConfigurationNotFoundError"),
+		},
+		{
+			name: "nil output without error",
+		},
+		{
+			name: "no lock configuration",
+			out:  &s3.GetObjectLockConfigurationOutput{},
+		},
+		{
+			name: "lock not enabled",
+			out: &s3.GetObjectLockConfigurationOutput{
+				ObjectLockConfiguration: &types.ObjectLockConfiguration{},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := objectLockUsable(tc.out, tc.err); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsObjectLockNotFound(t *testing.T) {
+	notFound := &smithy.GenericAPIError{Code: "ObjectLockConfigurationNotFoundError"}
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "not found code", err: notFound, want: true},
+		{name: "wrapped not found code", err: fmt.Errorf("probe: %w", notFound), want: true},
+		{name: "other api error", err: &smithy.GenericAPIError{Code: "AccessDenied"}},
+		{name: "plain error", err: errors.New("dial tcp: timeout")},
+		{name: "nil", err: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isObjectLockNotFound(tc.err); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}
+
+func equalTimePtr(a, b *time.Time) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Equal(*b)
 }
 
 func equalStringPtr(a, b *string) bool {


### PR DESCRIPTION
Add object_lock_enabled/mode/retention_days config

Startup probe falls back to unlocked uploads with a warning when the bucket has no object lock support.