### PR TITLE
fix(s3): download in range mode to avoid Ceph 412 on multipart SSE-C

### DIFF
--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -83,6 +83,8 @@ func NewS3(c config.S3, serviceName, restoreFolder, binLog string) (s3Storage *S
 	downloader := transfermanager.New(client, func(o *transfermanager.Options) {
 		o.PartSizeBytes = 64 * 1024 * 1024 // 64MB per part
 		o.Concurrency = 6
+		// Ceph's partNumber= responses trip the SDK's per-chunk If-Match check; range mode avoids it.
+		o.GetObjectType = tmtypes.GetObjectRanges
 	})
 
 	sseKey, sseKeyMD5 := encodeSSECustomerKey(c.SSECustomerKey)


### PR DESCRIPTION
- switch transfermanager downloader to GetObjectRanges
- default GetObjectParts issues ?partNumber=1, captures its response ETag, then attaches it as If-Match on partNumber=2+
- Ceph responds with the per-part ETag on partNumber=1, so the If-Match on subsequent parts never matches and every chunk after the first fails with 412 PreconditionFailed
- range mode uses byte offsets and receives the object's overall ETag, keeping If-Match consistent across chunks