### PR TITLE
fix(database): stop retrying slow_query_log toggle without SUPER

### DIFF
--- a/pkg/database/mariadb.go
+++ b/pkg/database/mariadb.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-mysql-org/go-mysql/client"
@@ -46,6 +47,10 @@ type (
 		logPosition       LogPosition
 		flushTimer        *time.Timer
 		slowQueryLogState slowQueryLogState
+
+		slowQueryLogMu              sync.Mutex
+		slowQueryLogProbeDone       bool
+		slowQueryLogToggleSupported bool
 	}
 	metadata struct {
 		Status binlog `yaml:"SHOW MASTER STATUS"`
@@ -707,6 +712,13 @@ func (m *MariaDB) restartMariaDB() (err error) {
 }
 
 func (m *MariaDB) setSlowQueryLog(state slowQueryLogState) (err error) {
+	m.slowQueryLogMu.Lock()
+	if m.slowQueryLogProbeDone && !m.slowQueryLogToggleSupported {
+		m.slowQueryLogMu.Unlock()
+		return nil
+	}
+	m.slowQueryLogMu.Unlock()
+
 	conn, err := client.Connect(fmt.Sprintf("%s:%s", m.cfg.Database.Host, strconv.Itoa(m.cfg.Database.Port)), m.cfg.Database.User, m.cfg.Database.Password, "")
 	if err != nil {
 		return
@@ -716,13 +728,33 @@ func (m *MariaDB) setSlowQueryLog(state slowQueryLogState) (err error) {
 			log.Error(fmt.Errorf("failed to close connection: %v", err))
 		}
 	}()
-	if m.slowQueryLogState != state {
-		_, err = conn.Execute(fmt.Sprintf("set global slow_query_log = '%s'", state))
-		if err == nil {
-			m.slowQueryLogState = state
-		}
+	if m.slowQueryLogState == state {
+		return nil
 	}
-	return
+	_, err = conn.Execute(fmt.Sprintf("set global slow_query_log = '%s'", state))
+	if err != nil {
+		if isAccessDenied(err) {
+			m.slowQueryLogMu.Lock()
+			m.slowQueryLogProbeDone = true
+			m.slowQueryLogToggleSupported = false
+			m.slowQueryLogMu.Unlock()
+			log.Warn("MariaDB user lacks SUPER privilege; slow_query_log toggling will be skipped for this process")
+			return nil
+		}
+		return
+	}
+	m.slowQueryLogState = state
+	m.slowQueryLogMu.Lock()
+	m.slowQueryLogProbeDone = true
+	m.slowQueryLogToggleSupported = true
+	m.slowQueryLogMu.Unlock()
+	return nil
+}
+
+// isAccessDenied reports whether err is a MariaDB "SUPER privilege required" (1227) error.
+func isAccessDenied(err error) bool {
+	var myErr *mysql.MyError
+	return errors.As(err, &myErr) && myErr.Code == mysql.ER_SPECIFIC_ACCESS_DENIED_ERROR
 }
 
 func getMyDumpBinlog(p string) (mp mysql.Position, err error) {

--- a/pkg/database/mariadb_test.go
+++ b/pkg/database/mariadb_test.go
@@ -38,3 +38,25 @@ func TestMariaDBDumpTool(t *testing.T) {
 		t.Error("expected an error, but got nil")
 	}
 }
+
+func TestSetSlowQueryLog_SkipsWhenUnsupported(t *testing.T) {
+	// Unreachable endpoint: if the short-circuit is missing, client.Connect returns a non-nil error.
+	cfg := config.Config{
+		Database: config.DatabaseConfig{
+			Host: "127.0.0.1",
+			Port: 1,
+		},
+	}
+
+	mdb, err := NewMariaDB(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("expected mariadb instance, got error: %s", err.Error())
+	}
+	m := mdb.(*MariaDB)
+	m.slowQueryLogProbeDone = true
+	m.slowQueryLogToggleSupported = false
+
+	if err := m.setSlowQueryLog(slowQueryLogOFF); err != nil {
+		t.Fatalf("expected nil (short-circuit), got %v", err)
+	}
+}


### PR DESCRIPTION
- Cache first 1227 result under a mutex; skip subsequent SET GLOBAL calls
- Log the decision once at Warn level